### PR TITLE
Componente/CardMenu

### DIFF
--- a/src/components/card-menu/card-menu.tsx
+++ b/src/components/card-menu/card-menu.tsx
@@ -1,25 +1,14 @@
-import { Card } from './card'
+import { ComponentProps } from 'react'
 import './card.css'
 
-interface cardMenuProps {
+interface cardMenuProps extends ComponentProps<'div'> {
 	className?: string
-	mode?: 'light' | 'dark'
-	labels: Array<string>
-	to: Array<string>
 }
 
-export function CardMenu({ className, mode, labels, to }: cardMenuProps) {
+export function CardMenu({ className, ...props }: cardMenuProps) {
 	const classes = className ? `${className} card-menu` : 'card-menu'
 
 	return (
-		<div className={classes}>
-			{
-				labels.map((label, i) => {
-					return (
-						<Card to={to[i]} mode={mode} label={label} key={i} />
-					)
-				})
-			}
-		</div>
+		<div className={classes} {...props} />
 	)
 }

--- a/src/pages/home-page/HomePage.tsx
+++ b/src/pages/home-page/HomePage.tsx
@@ -1,6 +1,7 @@
 import { cva, VariantProps } from 'class-variance-authority'
 import { Hero } from '../../components/hero/hero'
 import { CardMenu } from '../../components/card-menu/card-menu'
+import { Card } from '../../components/card-menu/card'
 import { Table } from '../../components/table/Table'
 import { Class, classes } from '../../data/mock/classes.mock'
 import './HomePage.css'
@@ -36,12 +37,11 @@ export function HomePage({ mode, ...props }: HomePageProps) {
         description='Acompanhe suas turmas e aulas e gerencie a presença de seus alunos.'
       />
 
-      <CardMenu
-        className='menu'
-        mode='light'
-        labels={['Agendar', 'Consultar', 'Eventos']}
-        to={['/', '/', '/']}
-      />
+      <CardMenu className='menu'>
+        <Card to='' label='Agendar' mode='light' />
+        <Card to='' label='Consultar' mode='light' />
+        <Card to='' label='Disciplinas' mode='light' />
+      </CardMenu>
 
       <div className='page-content'>
         <Table


### PR DESCRIPTION
Eu fui fazer a integração do modal de criação de aulas e percebi que a maneira que o CardMenu tava feito dificultava um pouco o uso dele pra abrir modais, então tive que alterar rapidinho rsrs.

Não foi coisa muito significativa não, eu só refiz a lógica pra ele aceitar Cards como children ao invés de renderizar eles a partir das labels passadas. Assim a gente pode atribuir as props de cada card de maneira melhor e mais controlada.