### PR TITLE
Component/select-input

### DIFF
--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -46,8 +46,7 @@
   color: var(--outline-base);
 }
 
-.date-input input::-webkit-calendar-picker-indicator,
-.time-input input::-webkit-calendar-picker-indicator  { 
+.input input::-webkit-calendar-picker-indicator { 
   display: none;
 }
 

--- a/src/components/select-input/select-input.css
+++ b/src/components/select-input/select-input.css
@@ -1,0 +1,41 @@
+.select-input {
+  width: 100%;
+  padding: 10px 15px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  border-radius: 8px;
+  border: 1px solid;
+
+  transition: 
+    border-color .2s ease-in-out;
+}
+
+.select-input.light {
+  border-color: var(--outline-base);
+  color: var(--base-black);
+}
+
+.select-input.light:focus-within {
+  border-color: var(--blue-base) !important;
+}
+
+.select-input.dark {
+  border-color: var(--outline-inverse);
+  color: var(--base-white);
+}
+
+.select-input.dark:focus-within {
+  border-color: var(--blue-inverse) !important;
+}
+
+.select-input select {
+  all: unset;
+  width: 100%;
+  padding: 0 5px;
+  font-family: "Karla", sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  cursor: pointer;
+}

--- a/src/components/select-input/select-input.tsx
+++ b/src/components/select-input/select-input.tsx
@@ -1,0 +1,37 @@
+import { ComponentProps } from 'react'
+import { cva, VariantProps } from 'class-variance-authority'
+import { Icon } from '../icon/icon'
+import './select-input.css'
+
+const selectInputVariants = cva(
+  'select-input',
+  {
+    variants: {
+      mode: {
+        light: 'light',
+        dark: 'dark'
+      }
+    },
+    defaultVariants: {
+      mode: 'light'
+    }
+  }
+)
+
+interface selectInputProps
+  extends ComponentProps<'select'>, VariantProps<typeof selectInputVariants> {
+    mode?: 'light' | 'dark'
+    placeholder?: string
+}
+
+export function SelectInput({ mode, placeholder, ...props }: selectInputProps) {
+  return (
+    <div className={selectInputVariants({ mode })}>
+      <select {...props}>
+        { placeholder && <option disabled selected>{placeholder}</option> }
+        {props.children}
+      </select>
+      <Icon className='input-icon' iconType='chevron-down' size={16} />
+    </div>
+  )
+}

--- a/src/components/select-input/select-input.tsx
+++ b/src/components/select-input/select-input.tsx
@@ -27,8 +27,8 @@ interface selectInputProps
 export function SelectInput({ mode, placeholder, ...props }: selectInputProps) {
   return (
     <div className={selectInputVariants({ mode })}>
-      <select {...props}>
-        { placeholder && <option disabled selected>{placeholder}</option> }
+      <select defaultValue='default' {...props}>
+        { placeholder && <option disabled value='default'>{placeholder}</option> }
         {props.children}
       </select>
       <Icon className='input-icon' iconType='chevron-down' size={16} />


### PR DESCRIPTION
# Componente SelectInput #

Genteee, eu alterei o input pra ter o select certinho. Como eu queria fazer da maneira mais fácil e direta, eu usei o select padrão mesmo do HTML, o que significa que o componente deixou de ser um input então, por boas práticas, eu tirei ele de dentro do Input e criei um componente à parte.

Resumindo, eu mantive o select input dentro do componente de Input pra caso vocês estejam usando em algum lugar, mas **lembrem de trocar para o SelectInput que tá na pasta prórpria dele**.