### PR TITLE
feat: setting up update passkey request

### DIFF
--- a/src/components/modal/lesson-detail-modal.tsx
+++ b/src/components/modal/lesson-detail-modal.tsx
@@ -5,6 +5,7 @@ import { Input } from "../input/input"
 import { ModalFooter } from "./modal-components/modal-footer"
 import { useState } from "react"
 import { Switch } from "../switch/switch"
+import { setPassKey } from "../../data/requests/attendance.requests"
 
 const classDetailVariants = cva(
   'base-modal input-modal',
@@ -51,7 +52,7 @@ export const LessonDetailModal = ({ mode, variant, close, className }: classDeta
   };
 
   const handleSubmit = () => {
-
+    setPassKey(lessonData.passkey)
   }
 
   const handleClose = () => {

--- a/src/data/requests/attendance.requests.ts
+++ b/src/data/requests/attendance.requests.ts
@@ -1,0 +1,16 @@
+import axios from "axios";
+
+const BASE_URL = 'http://localhost:8000/lesson/1/update_passkey'
+
+export const setPassKey = (passkey: string): boolean => {
+  axios.post(BASE_URL, {
+    passkey
+  }).then(res => {
+    console.log(res);
+    return true;
+  }).catch(err => {
+    console.log(err);
+    return false;
+  })
+  return false;
+}

--- a/src/data/requests/lesson.requests.ts
+++ b/src/data/requests/lesson.requests.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+const BASE_URL = 'http://localhost:8000/lesson/'
+
+export const getLesson = (id: number) => {
+  const lesson = axios.get(`${BASE_URL}${id}`)
+    .then(res => {
+      return res;
+    })
+    .catch(err => {
+      return err;
+    })
+    return lesson;
+}


### PR DESCRIPTION
A ideia desse PR (além de começar a integração) é só exemplificar o uso da camada de dados pra requests. 
Como é observável, não foi feito uso de mappers, mas a ideia seria criar uma função que transforme o objeto da request em um objeto utilizavel no typescript.  
Exemplo: 
![image](https://github.com/user-attachments/assets/babedf71-428c-4d40-86df-b6b87cecb2f7)
Dessa forma, poderia-se criar um objeto que contenha apenas os campos que se deseja, no formato que se deseja. Bastaria então que a função getUser, tivesse uma resposta do tipo: **mapUser(response)**
Mas a ideia era bem besta mesmo, só extrair chamadas pra fora do arquivo em que elas são feitas

Obs: 
> Vou abrir um terceiro PR em breve pra deixar redondinha a integração e validações, mas subi esse assim pra transmitir a ideia da camada de dados