### PR TITLE
Tela de Consulta de Aula

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import './App.css'
 
 import { HomePage } from './pages/home-page/HomePage'
 import { LessonsPage } from './pages/lessons-page/lessons-page'
+import { LessonDetailPage } from './pages/lesson-detail-page/lesson-detail-page'
 
 function App() {
   const location = useLocation()
@@ -23,10 +24,14 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/lessons" element={<LessonsPage />} />
+          <Route path="/lesson-detail" element={<LessonDetailPage />} />
           
           <Route path="/attendence" element={<h1 className='center'>Presença</h1>} />
           <Route path="/teachers" element={<h1 className='center'>Professores</h1>} />
-          <Route path="/classes" element={<h1 className='center'>Turmas</h1>} />
+          <Route path="/classes" element={
+            <LessonDetailPage />
+            // <h1 className='center'>Turmas</h1>
+          } />
           <Route path="/metrics" element={
             <div className='center'>
               <Button onClick={() => setOpen(true)}>Open Modal</Button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "./App.css";
 
 import { HomePage } from './pages/home-page/HomePage'
 import { LessonsPage } from './pages/lessons-page/lessons-page'
+import { LessonDetailPage } from './pages/lesson-detail-page/lesson-detail-page'
 
 function App() {
 	const location = useLocation();
@@ -23,10 +24,14 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/lessons" element={<LessonsPage />} />
+          <Route path="/lesson-detail" element={<LessonDetailPage />} />
           
           <Route path="/attendence" element={<h1 className='center'>Presença</h1>} />
           <Route path="/teachers" element={<h1 className='center'>Professores</h1>} />
-          <Route path="/classes" element={<h1 className='center'>Turmas</h1>} />
+          <Route path="/classes" element={
+            <LessonDetailPage />
+            // <h1 className='center'>Turmas</h1>
+          } />
           <Route path="/metrics" element={
             <div className='center'>
               <Button onClick={() => setOpen(true)}>Open Modal</Button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Button } from './components/button/Button'
 import './App.css'
 
 import { HomePage } from './pages/home-page/HomePage'
+import { LessonsPage } from './pages/lessons-page/lessons-page'
 
 function App() {
   const location = useLocation()
@@ -21,6 +22,8 @@ function App() {
 
         <Routes>
           <Route path="/" element={<HomePage />} />
+          <Route path="/lessons" element={<LessonsPage />} />
+          
           <Route path="/attendence" element={<h1 className='center'>Presença</h1>} />
           <Route path="/teachers" element={<h1 className='center'>Professores</h1>} />
           <Route path="/classes" element={<h1 className='center'>Turmas</h1>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/lessons" element={<LessonsPage />} />
-          <Route path="/lesson-detail" element={<LessonDetailPage />} />
+          <Route path="/lessons/:lessonID" element={<LessonDetailPage />} />
           
           <Route path="/attendence" element={<h1 className='center'>Presença</h1>} />
           <Route path="/teachers" element={<h1 className='center'>Professores</h1>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,8 @@ import { CreateClass } from "./components/modal/create-class";
 import { Button } from "./components/button/Button";
 import "./App.css";
 
-import { HomePage } from "./pages/home-page/HomePage";
-import { PresencePage } from "./pages/presence/PresencePage";
+import { HomePage } from './pages/home-page/HomePage'
+import { LessonsPage } from './pages/lessons-page/lessons-page'
 
 function App() {
 	const location = useLocation();
@@ -20,31 +20,23 @@ function App() {
 			<div className="page-container">
 				<Header to={location} />
 
-				<Routes>
-					<Route path="/" element={<HomePage />} />
-					<Route path="/attendence" element={<PresencePage />} />
-					<Route
-						path="/teachers"
-						element={<h1 className="center">Professores</h1>}
-					/>
-					<Route path="/classes" element={<h1 className="center">Turmas</h1>} />
-					<Route
-						path="/metrics"
-						element={
-							<div className="center">
-								<Button onClick={() => setOpen(true)}>Open Modal</Button>
-								<CreateClass
-									className={open ? "modal-open" : "modal-close"}
-									mode="light"
-									close={() => setOpen(false)}
-								/>
-							</div>
-						}
-					/>
-				</Routes>
-			</div>
-		</div>
-	);
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/lessons" element={<LessonsPage />} />
+          
+          <Route path="/attendence" element={<h1 className='center'>Presença</h1>} />
+          <Route path="/teachers" element={<h1 className='center'>Professores</h1>} />
+          <Route path="/classes" element={<h1 className='center'>Turmas</h1>} />
+          <Route path="/metrics" element={
+            <div className='center'>
+              <Button onClick={() => setOpen(true)}>Open Modal</Button>
+              <CreateClass className={open ? 'modal-open' : 'modal-close'} mode='light' close={() => setOpen(false)} />
+            </div>
+          } />
+        </Routes>
+      </div>
+    </div>
+  )
 }
 
 export default App;

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -23,8 +23,10 @@ import ChevronRight from "../../assets/icons/style_guide/icon-chevron-right.svg?
 import ChevronsRight from "../../assets/icons/style_guide/icon-chevrons-right.svg?react";
 import ChevronUp from "../../assets/icons/style_guide/icon-chevron-up.svg?react";
 import ChevronsUp from "../../assets/icons/style_guide/icon-chevrons-up.svg?react";
+import Clipboard from "../../assets/icons/style_guide/icon-clipboard.svg?react";
 import Clock from "../../assets/icons/style_guide/icon-clock.svg?react";
 import File from "../../assets/icons/style_guide/icon-file.svg?react";
+import Lock from "../../assets/icons/style_guide/icon-lock.svg?react";
 import Logout from "../../assets/icons/style_guide/icon-log-out.svg?react";
 import Trash from "../../assets/icons/style_guide/icon-trash.svg?react";
 import Search from "../../assets/icons/style_guide/icon-search.svg?react";
@@ -72,8 +74,10 @@ export const Icon = (props: IconProps) => {
     case "chevrons-right" : return <ChevronsRight style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
     case "chevron-up" : return <ChevronUp style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
     case "chevrons-up" : return <ChevronsUp style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
+    case "clipboard" : return <Clipboard style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
     case "clock" : return <Clock style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
     case "file" : return <File style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
+    case "lock" : return <Lock style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
     case "logout" : return <Logout style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
     case "trash" : return <Trash style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;
     case "search" : return <Search style={{ width: props.size || '24px', height: props.size || '24px' }} className={classes} />;

--- a/src/components/search/search.css
+++ b/src/components/search/search.css
@@ -1,0 +1,67 @@
+.search {
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  border-radius: 8px;
+  border: 1px solid;
+
+  transition: 
+    border-color .2s ease-in-out;
+}
+
+.search.light {
+  border-color: var(--outline-base);
+  background-color: var(--base-white);
+  color: var(--base-black);
+}
+
+.search.light:focus-within {
+  border-color: var(--blue-base) !important;
+}
+
+.search.dark {
+  border-color: var(--outline-inverse);
+  background-color: var(--base-gray);
+  color: var(--base-white);
+}
+
+.search.dark:focus-within {
+  border-color: var(--blue-inverse) !important;
+}
+
+.search input {
+  all: unset;
+  width: 100%;
+  font-family: "Karla", sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+}
+
+.search input::placeholder {
+  color: var(--outline-base);
+}
+
+.search input::-ms-input-placeholder {
+  color: var(--outline-base);
+}
+
+.search .clear-icon {
+  cursor: pointer;
+
+  transition: 
+    transform .2s ease-in-out;
+}
+
+.search .clear-icon:hover {
+  transform: scale(1.2);
+}
+
+.search.light .clear-icon {
+  color: var(--outline-base);
+}
+
+.search.dark .clear-icon {
+  color: var(--outline-inverse);
+}

--- a/src/components/search/search.css
+++ b/src/components/search/search.css
@@ -36,7 +36,7 @@
   width: 100%;
   font-family: "Karla", sans-serif;
   font-weight: 300;
-  font-size: 16px;
+  font-size: 12px;
 }
 
 .search input::placeholder {

--- a/src/components/search/search.tsx
+++ b/src/components/search/search.tsx
@@ -1,0 +1,37 @@
+import { ComponentProps } from 'react'
+import { cva, VariantProps } from 'class-variance-authority'
+import { Icon } from '../icon/icon'
+import './search.css'
+
+const searchVariants = cva(
+  'search',
+  {
+    variants: {
+      mode: {
+        light: 'light',
+        dark: 'dark'
+      }
+    },
+    defaultVariants: {
+      mode: 'light'
+    }
+  }
+)
+
+interface searchProps
+  extends ComponentProps<'input'>, VariantProps<typeof searchVariants> {
+    mode?: 'light' | 'dark'
+}
+
+export function Search({ mode, ...props }: searchProps) {
+  return (
+    <div className={searchVariants({ mode })}>
+      <Icon className='input-icon' iconType='search' size={16} />
+      <input type='text' {...props} />
+
+      {/* <div onClick={}>
+        <Icon className='clear-icon' iconType='x-circle' size={14} />
+      </div> */}
+    </div>
+  )
+}

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -1,7 +1,6 @@
-import { ComponentProps, ReactNode, useState } from "react";
+import { Children, ComponentProps, useState } from "react";
 import { cva, VariantProps } from "class-variance-authority";
 import { TableHeader } from "./TableHeader";
-import { TableRow } from "./TableRow";
 import { TableFooter } from "./TableFooter";
 import "./Table.css";
 
@@ -18,43 +17,23 @@ const TableVariants = cva("base-table", {
 });
 
 interface TableProps
-	extends ComponentProps<"table">,
-		VariantProps<typeof TableVariants> {
-	mode?: "light" | "dark";
-	clickable?: boolean;
-	header: Array<string>;
-	data: Array<Array<ReactNode>>;
-	onClick?: () => void;
+	extends ComponentProps<"table">, VariantProps<typeof TableVariants> {
+		mode?: "light" | "dark";
+		clickable?: boolean;
+		header: Array<string>;
+		onClick?: () => void;
 }
 
-export function Table({
-	mode,
-	clickable,
-	header,
-	data,
-	onClick,
-	...props
-}: TableProps) {
-	const [page, setPage] = useState(1);
-	const maxPage = Math.ceil(data.length / 10);
+export function Table({ mode, clickable, header, onClick, ...props }: TableProps) {
+	const [ page, setPage ] = useState(1);
+	const maxPage = Math.ceil(Children.count(props.children) / 10);
 
 	return (
 		<table className={TableVariants({ mode })} {...props}>
 			<TableHeader mode={mode} clickable={clickable} headers={header} />
 
 			<tbody>
-				{data.slice((page - 1) * 10, page * 10).map((row, i) => {
-					return (
-						<TableRow
-							mode={mode}
-							clickable={clickable}
-							key={i}
-							onClick={onClick}
-						>
-							{row}
-						</TableRow>
-					);
-				})}
+				{ Children.toArray(props.children).slice((page - 1) * 10, page * 10) }
 			</tbody>
 
 			<TableFooter

--- a/src/components/table/TableRow.tsx
+++ b/src/components/table/TableRow.tsx
@@ -1,4 +1,4 @@
-import { Children, ComponentProps, ReactNode } from "react";
+import { ComponentProps } from "react";
 import { cva, VariantProps } from "class-variance-authority";
 import "./Table.css";
 
@@ -20,11 +20,9 @@ const TableRowVariants = cva("table-row", {
 });
 
 interface TableRowProps
-	extends ComponentProps<"tr">,
-		VariantProps<typeof TableRowVariants> {
-	mode?: "light" | "dark";
-	clickable?: boolean;
-	children: ReactNode;
+	extends ComponentProps<"tr">, VariantProps<typeof TableRowVariants> {
+		mode?: "light" | "dark";
+		clickable?: boolean;
 }
 
 export function TableRow({ mode, clickable, ...props }: TableRowProps) {
@@ -35,10 +33,7 @@ export function TableRow({ mode, clickable, ...props }: TableRowProps) {
 
 	return (
 		<tr className={TableRowVariants({ mode, clickable })} {...props}>
-			{props.children &&
-				Children.map(props.children, (child, i) => {
-					return <td key={i}>{child}</td>;
-				})}
+			{ props.children }
 			<td className="icon">{">"}</td>
 		</tr>
 	);

--- a/src/components/text-card/text-card.css
+++ b/src/components/text-card/text-card.css
@@ -1,0 +1,53 @@
+.text-card {
+  width: 150px;
+  height: 80px;
+  border-radius: 5px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  gap: 10px;
+}
+
+.text-card .header {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+
+  h6 {
+    font-size: 14px;
+    font-weight: 500;
+  }
+}
+
+.text-card p {
+  font-size: 16px;
+}
+
+.text-card.light {
+  border: 1px solid var(--outline-base);
+  background: var(--base-white);
+
+  .header {
+    color: var(--outline-base);
+  }
+
+  p {
+    color: var(--base-black);
+  }
+}
+
+.text-card.dark {
+  border: 1px solid var(--outline-inverse);
+  background: var(--base-gray);
+
+  .header {
+    color: var(--outline-inverse);
+  }
+
+  p {
+    color: var(--base-white);
+  }
+}

--- a/src/components/text-card/text-card.tsx
+++ b/src/components/text-card/text-card.tsx
@@ -1,0 +1,38 @@
+import { ComponentProps } from 'react'
+import { cva, VariantProps } from 'class-variance-authority'
+import { Icon } from '../icon/icon'
+import './text-card.css'
+
+const TextCardVariants = cva(
+  'text-card',
+  {
+    variants: {
+      mode: {
+        light: 'light',
+        dark: 'dark'
+      }
+    },
+    defaultVariants: {
+      mode: 'light'
+    }
+  }
+)
+
+interface TextCardProps
+  extends ComponentProps<'div'>, VariantProps<typeof TextCardVariants> {
+    mode?: 'light' | 'dark'
+    label?: string
+    iconType?: string
+}
+
+export function TextCard({ mode, label, iconType, ...props }: TextCardProps) {
+  return (
+    <div className={TextCardVariants({ mode })} {...props}>
+      <div className='header'>
+        { iconType && <Icon iconType={iconType} size={16} /> }
+        { label && <h6>{label}</h6> }        
+      </div>
+      <p>{ props.children }</p>
+    </div>
+  )
+}

--- a/src/data/mapper/lesson.mapper.ts
+++ b/src/data/mapper/lesson.mapper.ts
@@ -1,0 +1,18 @@
+import { Lesson, LessonInterface } from "../models/lesson.model";
+
+export const mapLesson = (data: any) => {
+  let lessonData: LessonInterface = {
+    id: data.id,
+    name: data.name,
+    startTime: new Date(data.start_datetime),
+    endTime: new Date(data.end_datetime),
+    studentClass: {name: 'Turma 1'},
+    subject: {name: 'Matemática'},
+    startAttendance: new Date (data.attendance_start_datetime),
+    endAttendance: new Date (data.attendance_end_datetime),
+    isAttendanceRegistrable: false,
+    passkey: 'PASSWORD',
+  }
+
+  return new Lesson(lessonData)
+}

--- a/src/data/mock/classes.mock.ts
+++ b/src/data/mock/classes.mock.ts
@@ -1,339 +1,339 @@
 export interface Class {
-    aula: string
-    horario: string
-    turma: string
-    column: string
-  }
+  aula: string
+  horario: string
+  turma: string
+  column: string
+}
   
-  export const classes:Array<Class> = [
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Matemática',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Português',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Física',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Química',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-    {
-      aula: 'Geografia',
-      horario: '21h00',
-      turma: 'Turma 1',
-      column: 'Value'
-    },
-  ]
+export const classes:Array<Class> = [
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Matemática',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Português',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Física',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Química',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+  {
+    aula: 'Geografia',
+    horario: '21h00',
+    turma: 'Turma 1',
+    column: 'Value'
+  },
+]

--- a/src/data/models/class.model.ts
+++ b/src/data/models/class.model.ts
@@ -1,8 +1,8 @@
 import { Subject } from "./subject.model";
 
-export interface Class {
-    name: string;
-    classroom: string;
-    course?: string;
-    subjects: Subject[];
+export interface StudentClass {
+  name: string;
+  // classroom: string;
+  // course?: string;
+  // subjects: Subject[];
 }

--- a/src/data/models/lesson.model.ts
+++ b/src/data/models/lesson.model.ts
@@ -1,12 +1,53 @@
-import { Class } from "./class.model";
+import { StudentClass } from "./class.model";
 import { Subject } from "./subject.model";
 
-export interface Lesson {
-    courseClass: Class;
-    subject: Subject; 
+export interface LessonInterface {
+  id: number
+  name: string
+  startTime: Date
+  endTime: Date
+  studentClass: StudentClass
+  subject: Subject
+  startAttendance: Date
+  endAttendance: Date
+  isAttendanceRegistrable: boolean
+  passkey: string
 }
 
-export interface LessonDateTime {
-    lesson: Lesson;
-    dateTime: Date;
+export class Lesson implements LessonInterface {
+  id: number
+  name: string
+  startTime: Date
+  endTime: Date
+  studentClass: StudentClass
+  subject: Subject
+  startAttendance: Date
+  endAttendance: Date
+  isAttendanceRegistrable: boolean
+  passkey: string
+
+  constructor(params: LessonInterface) {
+    this.id = params.id
+    this.name = params.name
+    this.startTime = params.startTime
+    this.endTime = params.endTime
+    this.studentClass = params.studentClass
+    this.subject = params.subject
+    this.startAttendance = params.startAttendance
+    this.endAttendance = params.endAttendance
+    this.isAttendanceRegistrable = params.isAttendanceRegistrable
+    this.passkey = params.passkey
+  }
+
+  dateFormat(style: 'medium' | 'short'): string {
+    return this.startTime.toLocaleDateString('pt-br', {dateStyle: style})
+  }
+
+  startTimeFormat(): string {
+    return this.startTime.toLocaleTimeString('pt-br', {timeStyle: 'short'})
+  }
+
+  endTimeFormat(): string {
+    return this.endTime.toLocaleTimeString('pt-br', {timeStyle: 'short'})
+  }
 }

--- a/src/data/models/lesson.model.ts
+++ b/src/data/models/lesson.model.ts
@@ -44,10 +44,18 @@ export class Lesson implements LessonInterface {
   }
 
   startTimeFormat(): string {
-    return this.startTime.toLocaleTimeString('pt-br', {timeStyle: 'short'})
+    return this.startTime.toLocaleTimeString('pt-br', {timeStyle: 'short', hour12: false})
   }
 
   endTimeFormat(): string {
-    return this.endTime.toLocaleTimeString('pt-br', {timeStyle: 'short'})
+    return this.endTime.toLocaleTimeString('pt-br', {timeStyle: 'short', hour12: false})
+  }
+
+  startAttendanceFormat(): string {
+    return this.startAttendance.toLocaleTimeString('pt-br', {timeStyle: 'short', hour12: false})
+  }
+
+  endAttendanceFormat(): string {
+    return this.endAttendance.toLocaleTimeString('pt-br', {timeStyle: 'short', hour12: false})
   }
 }

--- a/src/data/models/subject.model.ts
+++ b/src/data/models/subject.model.ts
@@ -1,3 +1,3 @@
 export interface Subject {
-    name: string;
+	name: string;
 }

--- a/src/data/requests/lesson.requests.ts
+++ b/src/data/requests/lesson.requests.ts
@@ -1,5 +1,4 @@
 import axios from "axios"
-import { Lesson } from "../models/lesson.model"
 import { mapLesson } from "../mapper/lesson.mapper"
 
 const BASE_URL = 'http://localhost:8000/lesson/'

--- a/src/data/requests/lesson.requests.ts
+++ b/src/data/requests/lesson.requests.ts
@@ -10,7 +10,6 @@ export const getLessons = () => {
       return data
     })
     .catch(error => {
-      console.log(error)
       return error
     })
   
@@ -18,12 +17,13 @@ export const getLessons = () => {
 }
 
 export const getLesson = (id: number) => {
-  const lesson = axios.get(`${BASE_URL}${id}`)
-    .then(res => {
-      return res;
+  const lesson = axios.get(`${BASE_URL}${id}/`)
+    .then(response => {
+      return mapLesson(response.data)
     })
-    .catch(err => {
-      return err;
+    .catch(error => {
+      return error;
     })
-    return lesson;
+
+  return lesson;
 }

--- a/src/data/requests/lesson.requests.ts
+++ b/src/data/requests/lesson.requests.ts
@@ -1,6 +1,22 @@
-import axios from "axios";
+import axios from "axios"
+import { Lesson } from "../models/lesson.model"
+import { mapLesson } from "../mapper/lesson.mapper"
 
 const BASE_URL = 'http://localhost:8000/lesson/'
+
+export const getLessons = () => {
+  const lessons = axios.get(BASE_URL)
+    .then(response => {
+      const data = response.data.map((data: any) => mapLesson(data))
+      return data
+    })
+    .catch(error => {
+      console.log(error)
+      return error
+    })
+  
+  return lessons
+}
 
 export const getLesson = (id: number) => {
   const lesson = axios.get(`${BASE_URL}${id}`)

--- a/src/pages/home-page/HomePage.css
+++ b/src/pages/home-page/HomePage.css
@@ -11,7 +11,7 @@
   position: relative;
 }
 
-.menu {
+.home .menu {
   position: absolute;
   top: 130px;
   left: 60px;

--- a/src/pages/lesson-detail-page/lesson-detail-page.css
+++ b/src/pages/lesson-detail-page/lesson-detail-page.css
@@ -1,10 +1,14 @@
+.page.lesson-detail {
+  gap: 50px;
+}
+
 .lesson-detail .page-content {
   padding: 0 60px;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   justify-content: flex-start;
-  gap: 20px;
+  gap: 40px;
 }
 
 .lesson-detail {
@@ -22,5 +26,16 @@
   flex-direction: column;
   align-items: stretch;
   justify-content: center;
+  gap: 20px;
+}
+
+.lesson-detail .info {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.lesson-detail .cards {
+  display: flex;
   gap: 20px;
 }

--- a/src/pages/lesson-detail-page/lesson-detail-page.css
+++ b/src/pages/lesson-detail-page/lesson-detail-page.css
@@ -1,4 +1,4 @@
-.lessons .page-content {
+.lesson-detail .page-content {
   padding: 0 60px;
   display: flex;
   flex-direction: column;
@@ -7,17 +7,17 @@
   gap: 20px;
 }
 
-.lessons {
+.lesson-detail {
   position: relative;
 }
 
-.lessons .menu {
+.lesson-detail .menu {
   position: absolute;
   top: 130px;
-  left: 60px;
+  right: 60px;
 }
 
-.lessons .lesson-table {
+.lesson-detail .lesson-table {
   display: flex;
   flex-direction: column;
   align-items: stretch;

--- a/src/pages/lesson-detail-page/lesson-detail-page.tsx
+++ b/src/pages/lesson-detail-page/lesson-detail-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
 import { cva, VariantProps } from 'class-variance-authority'
 import { Hero } from '../../components/hero/hero'
 import { CardMenu } from '../../components/card-menu/card-menu'
@@ -9,6 +10,8 @@ import { Table } from '../../components/table/Table'
 import { TableRow } from '../../components/table/TableRow'
 
 import { classes } from '../../data/mock/classes.mock'
+import { getLesson } from '../../data/requests/lesson.requests'
+import { Lesson } from '../../data/models/lesson.model'
 import './lesson-detail-page.css'
 
 const LessonDetailPageVariants = cva(
@@ -32,6 +35,18 @@ interface LessonDetailPageProps extends VariantProps<typeof LessonDetailPageVari
 
 export function LessonDetailPage({ mode, ...props }: LessonDetailPageProps) {
   const [ search, setSearch ] = useState<string>('')
+  const [ lesson, setLesson ] = useState<Lesson>()
+  const { lessonID } = useParams()
+
+  useEffect(() => {
+    lessonID && getLesson(parseInt(lessonID))
+      .then(data => {
+        setLesson(data)
+      })
+      .catch(error => {
+        console.log(error)
+      })
+  }, []);
 
   const filterLesson = (e:any) => {
     setSearch(e.target.value)
@@ -40,8 +55,8 @@ export function LessonDetailPage({ mode, ...props }: LessonDetailPageProps) {
   return (
     <div className={LessonDetailPageVariants({ mode })} {...props}>
       <Hero 
-        title='Aula de Matemática'
-        description='Matemática • Turma 1'
+        title={`${lesson?.name}`}
+        description={`${lesson?.subject.name} • ${lesson?.studentClass.name}`}
       />
 
       <CardMenu className='menu'>
@@ -53,10 +68,10 @@ export function LessonDetailPage({ mode, ...props }: LessonDetailPageProps) {
         <div className='info'>
           <h5>Informações</h5>
           <div className='cards'>
-            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
-            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
-            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
-            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
+            <TextCard iconType='calendar' label='Data'>{lesson?.dateFormat('short')}</TextCard>
+            <TextCard iconType='clock' label='Horário'>{`${lesson?.startTimeFormat()} - ${lesson?.endTimeFormat()}`}</TextCard>
+            <TextCard iconType='clipboard' label='Presença'>{`${lesson?.startAttendanceFormat()} - ${lesson?.endAttendanceFormat()}`}</TextCard>
+            <TextCard iconType='lock' label='Palavra-chave'>{lesson?.passkey}</TextCard>
           </div>
         </div>
         

--- a/src/pages/lesson-detail-page/lesson-detail-page.tsx
+++ b/src/pages/lesson-detail-page/lesson-detail-page.tsx
@@ -1,0 +1,102 @@
+import { useState, useEffect } from 'react'
+import { cva, VariantProps } from 'class-variance-authority'
+import { Hero } from '../../components/hero/hero'
+import { CardMenu } from '../../components/card-menu/card-menu'
+import { Card } from '../../components/card-menu/card'
+import { Search } from '../../components/search/search'
+import { Table } from '../../components/table/Table'
+
+import axios from 'axios';
+import './lesson-detail-page.css'
+
+interface Classes {
+  id: number
+  name: string
+  start_datetime: string
+  end_datetime: string
+  attendance_start_datetime: string
+  attendance_end_datetime: string
+  is_attendance_registrable: boolean
+  lesson_recurrency: number
+}
+
+const LessonDetailPageVariants = cva(
+  'lesson-detail page',
+  {
+    variants: {
+      mode: {
+        light: 'light',
+        dark: 'dark'
+      }
+    },
+    defaultVariants: {
+      mode: 'light'
+    }
+  }
+)
+
+interface LessonDetailPageProps extends VariantProps<typeof LessonDetailPageVariants> {
+  mode?: 'light' | 'dark'
+}
+
+export function LessonDetailPage({ mode, ...props }: LessonDetailPageProps) {
+  // const [ classData, setClassData ] = useState([])
+  // const [ search, setSearch ] = useState<string>('')
+  // const [ lessons, setLessons ] = useState<string[][]>([])
+
+  // useEffect(() => {
+  //   axios.get('http://127.0.0.1:8000/lesson/')
+  //     .then(response => {
+  //       setClassData(response.data.map((obj:any) => {
+  //         // return (Object.keys(obj).map((key) => obj[key as keyof Classes]))
+  //         return ([obj.name, obj.id, obj.start_datetime])
+  //       }))
+
+  //       setLessons(response.data.map((obj:any) => {
+  //         // return (Object.keys(obj).map((key) => obj[key as keyof Classes]))
+  //         return ([obj.name, obj.id, obj.start_datetime])
+  //       }))
+  //     })
+  //     .catch(error => {
+  //       console.log(error);
+  //     });
+  // }, []);
+
+
+
+  // const filterLesson = (e:any) => {
+  //   setSearch(e.target.value)
+
+  //   if (e.target.value == '') {
+  //     setLessons(classData)
+  //   } else {
+  //     setLessons(classData.filter((lesson) => lesson[0].includes(e.target.value)))
+  //   }
+  // }
+
+  return (
+    <div className={LessonDetailPageVariants({ mode })} {...props}>
+      <Hero 
+        title='Aula de Matemática'
+        description='Matemática • Turma 1'
+      />
+
+      <CardMenu className='menu'>
+        <Card to='' label='Editar' mode='light' />
+        <Card to='' label='Excluir' mode='light' />
+      </CardMenu>
+
+      <div className='page-content'>
+        <div className='lesson-table'>
+          {/* <Search value={search} onChange={filterLesson} /> */}
+          {/* <Table
+            mode='light'
+            clickable={true}
+            header={['Aula', 'ID', 'Datetime']}
+            data={lessons}
+          /> */}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/lesson-detail-page/lesson-detail-page.tsx
+++ b/src/pages/lesson-detail-page/lesson-detail-page.tsx
@@ -1,24 +1,15 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { cva, VariantProps } from 'class-variance-authority'
 import { Hero } from '../../components/hero/hero'
 import { CardMenu } from '../../components/card-menu/card-menu'
 import { Card } from '../../components/card-menu/card'
+import { TextCard } from '../../components/text-card/text-card'
 import { Search } from '../../components/search/search'
 import { Table } from '../../components/table/Table'
+import { TableRow } from '../../components/table/TableRow'
 
-import axios from 'axios';
+import { classes } from '../../data/mock/classes.mock'
 import './lesson-detail-page.css'
-
-interface Classes {
-  id: number
-  name: string
-  start_datetime: string
-  end_datetime: string
-  attendance_start_datetime: string
-  attendance_end_datetime: string
-  is_attendance_registrable: boolean
-  lesson_recurrency: number
-}
 
 const LessonDetailPageVariants = cva(
   'lesson-detail page',
@@ -40,39 +31,11 @@ interface LessonDetailPageProps extends VariantProps<typeof LessonDetailPageVari
 }
 
 export function LessonDetailPage({ mode, ...props }: LessonDetailPageProps) {
-  // const [ classData, setClassData ] = useState([])
-  // const [ search, setSearch ] = useState<string>('')
-  // const [ lessons, setLessons ] = useState<string[][]>([])
+  const [ search, setSearch ] = useState<string>('')
 
-  // useEffect(() => {
-  //   axios.get('http://127.0.0.1:8000/lesson/')
-  //     .then(response => {
-  //       setClassData(response.data.map((obj:any) => {
-  //         // return (Object.keys(obj).map((key) => obj[key as keyof Classes]))
-  //         return ([obj.name, obj.id, obj.start_datetime])
-  //       }))
-
-  //       setLessons(response.data.map((obj:any) => {
-  //         // return (Object.keys(obj).map((key) => obj[key as keyof Classes]))
-  //         return ([obj.name, obj.id, obj.start_datetime])
-  //       }))
-  //     })
-  //     .catch(error => {
-  //       console.log(error);
-  //     });
-  // }, []);
-
-
-
-  // const filterLesson = (e:any) => {
-  //   setSearch(e.target.value)
-
-  //   if (e.target.value == '') {
-  //     setLessons(classData)
-  //   } else {
-  //     setLessons(classData.filter((lesson) => lesson[0].includes(e.target.value)))
-  //   }
-  // }
+  const filterLesson = (e:any) => {
+    setSearch(e.target.value)
+  }
 
   return (
     <div className={LessonDetailPageVariants({ mode })} {...props}>
@@ -87,14 +50,30 @@ export function LessonDetailPage({ mode, ...props }: LessonDetailPageProps) {
       </CardMenu>
 
       <div className='page-content'>
+        <div className='info'>
+          <h5>Informações</h5>
+          <div className='cards'>
+            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
+            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
+            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
+            <TextCard iconType='align-justify' label='Modalidade'>MODALIDADE</TextCard>
+          </div>
+        </div>
+        
         <div className='lesson-table'>
-          {/* <Search value={search} onChange={filterLesson} /> */}
-          {/* <Table
-            mode='light'
-            clickable={true}
-            header={['Aula', 'ID', 'Datetime']}
-            data={lessons}
-          /> */}
+          <Search value={search} onChange={filterLesson} />
+          <Table mode='light' clickable={true} header={['Aula', 'Horário', 'Turma', 'Column']}>
+            {
+              classes.map((lesson, i) => { return (
+                <TableRow key={i}>
+                  <td>{lesson.aula}</td>
+                  <td>{lesson.horario}</td>
+                  <td>{lesson.turma}</td>
+                  <td>{lesson.column}</td>
+                </TableRow>
+              )})
+            }
+          </Table>
         </div>
       </div>
     </div>

--- a/src/pages/lessons-page/lessons-page.css
+++ b/src/pages/lessons-page/lessons-page.css
@@ -7,7 +7,7 @@
   gap: 50px;
 }
 
-.home {
+.lessons {
   position: relative;
 }
 

--- a/src/pages/lessons-page/lessons-page.css
+++ b/src/pages/lessons-page/lessons-page.css
@@ -1,10 +1,10 @@
-.page-content {
+.lessons .page-content {
   padding: 0 60px;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-start;
-  gap: 50px;
+  gap: 20px;
 }
 
 .lessons {
@@ -15,4 +15,12 @@
   position: absolute;
   top: 130px;
   left: 60px;
+}
+
+.lessons .lesson-table {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  gap: 20px;
 }

--- a/src/pages/lessons-page/lessons-page.tsx
+++ b/src/pages/lessons-page/lessons-page.tsx
@@ -4,10 +4,10 @@ import { CardMenu } from '../../components/card-menu/card-menu'
 import { Card } from '../../components/card-menu/card'
 import { Table } from '../../components/table/Table'
 import { Class, classes } from '../../data/mock/classes.mock'
-import './HomePage.css'
+import './lessons-page.css'
 
-const HomePageVariants = cva(
-  'home page',
+const LessonsPageVariants = cva(
+  'lessons page',
   {
     variants: {
       mode: {
@@ -21,25 +21,24 @@ const HomePageVariants = cva(
   }
 )
 
-interface HomePageProps extends VariantProps<typeof HomePageVariants> {
+interface LessonsPageProps extends VariantProps<typeof LessonsPageVariants> {
   mode?: 'light' | 'dark'
 }
 
-export function HomePage({ mode, ...props }: HomePageProps) {
+export function LessonsPage({ mode, ...props }: LessonsPageProps) {
   const classData = classes.map((obj) => {
     return (Object.keys(obj).map((key) => obj[key as keyof Class]))
   })
 
   return (
-    <div className={HomePageVariants({ mode })} {...props}>
+    <div className={LessonsPageVariants({ mode })} {...props}>
       <Hero 
-        title='Bem-vindo, Lucas!'
-        description='Acompanhe suas turmas e aulas e gerencie a presença de seus alunos.'
+        title='Consultar aulas'
+        description='Veja as suas aulas que foram agendadas dentro do período de 1 mês.'
       />
 
       <CardMenu className='menu'>
         <Card to='' label='Agendar' mode='light' />
-        <Card to='/lessons' label='Consultar' mode='light' />
         <Card to='' label='Disciplinas' mode='light' />
       </CardMenu>
 

--- a/src/pages/lessons-page/lessons-page.tsx
+++ b/src/pages/lessons-page/lessons-page.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { cva, VariantProps } from 'class-variance-authority'
 import { Hero } from '../../components/hero/hero'
 import { CardMenu } from '../../components/card-menu/card-menu'
@@ -34,6 +35,7 @@ export function LessonsPage({ mode, ...props }: LessonsPageProps) {
   const [ lessons, setLessons ] = useState(Array<Lesson>)
   const [ filtered, setFiltered ] = useState(Array<Lesson>)
   const [ search, setSearch ] = useState<string>('')
+  const nav = useNavigate()
   
   useEffect(() => {
     getLessons()
@@ -75,7 +77,7 @@ export function LessonsPage({ mode, ...props }: LessonsPageProps) {
             <Table clickable={true} header={['Aula', 'Data', 'Hora', 'Turma']}>
               {
                 filtered.map((lesson) => { return (
-                  <TableRow key={lesson.id}>
+                  <TableRow key={lesson.id} onClick={() => nav(`/lessons/${lesson.id}`)}>
                     <td>{lesson.name}</td>
                     <td>{lesson.dateFormat('medium')}</td>
                     <td>{lesson.startTimeFormat()}</td>

--- a/src/pages/lessons-page/lessons-page.tsx
+++ b/src/pages/lessons-page/lessons-page.tsx
@@ -1,10 +1,24 @@
+import { useState, useEffect } from 'react'
 import { cva, VariantProps } from 'class-variance-authority'
 import { Hero } from '../../components/hero/hero'
 import { CardMenu } from '../../components/card-menu/card-menu'
 import { Card } from '../../components/card-menu/card'
+import { Search } from '../../components/search/search'
 import { Table } from '../../components/table/Table'
-import { Class, classes } from '../../data/mock/classes.mock'
+
+import axios from 'axios';
 import './lessons-page.css'
+
+interface Classes {
+  id: number
+  name: string
+  start_datetime: string
+  end_datetime: string
+  attendance_start_datetime: string
+  attendance_end_datetime: string
+  is_attendance_registrable: boolean
+  lesson_recurrency: number
+}
 
 const LessonsPageVariants = cva(
   'lessons page',
@@ -26,9 +40,41 @@ interface LessonsPageProps extends VariantProps<typeof LessonsPageVariants> {
 }
 
 export function LessonsPage({ mode, ...props }: LessonsPageProps) {
-  const classData = classes.map((obj) => {
-    return (Object.keys(obj).map((key) => obj[key as keyof Class]))
-  })
+  const [ classData, setClassData ] = useState([])
+  const [ search, setSearch ] = useState<string>('')
+  const [ lessons, setLessons ] = useState<string[][]>([])
+
+  useEffect(() => {
+    axios.get('http://127.0.0.1:8000/lesson/')
+      .then(response => {
+        setClassData(response.data.map((obj:any) => {
+          // return (Object.keys(obj).map((key) => obj[key as keyof Classes]))
+          return ([obj.name, obj.id, obj.start_datetime])
+        }))
+
+        setLessons(response.data.map((obj:any) => {
+          // return (Object.keys(obj).map((key) => obj[key as keyof Classes]))
+          return ([obj.name, obj.id, obj.start_datetime])
+        }))
+      })
+      .catch(error => {
+        console.log(error);
+      });
+  }, []);
+
+
+
+  const filterLesson = (e:any) => {
+    setSearch(e.target.value)
+
+    if (e.target.value == '') {
+      setLessons(classData)
+    } else {
+      setLessons(classData.filter((lesson) => lesson[0].includes(e.target.value)))
+    }
+  }
+
+  console.log(lessons)
 
   return (
     <div className={LessonsPageVariants({ mode })} {...props}>
@@ -43,12 +89,15 @@ export function LessonsPage({ mode, ...props }: LessonsPageProps) {
       </CardMenu>
 
       <div className='page-content'>
-        <Table
-          mode='light'
-          clickable={true}
-          header={['Aula', 'Horário', 'Turma', 'Column']}
-          data={classData}
-        />
+        <div className='lesson-table'>
+          <Search value={search} onChange={filterLesson} />
+          <Table
+            mode='light'
+            clickable={true}
+            header={['Aula', 'ID', 'Datetime']}
+            data={lessons}
+          />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
# Telas de consulta de aulas geral e por ID

Talvez seja um PR meio grande (desculpa foi meio que o desespero) mas ele basicamente implementa as telas de consulta de todas as aulas e de uma aula específica por ID. Esse PR envolve algumas coisinhas, como:

- Adição de 2 novos ícones (Lock e Clipboard);
- Novo padrão da tabela passado na weekly;
- Tela de aulas geral;
- Tela de uma aula por ID;
- Modelo, mapper e funções de request referentes às telas;
- Integração.

Só lembrando que ainda faltam algumas coisas nessas telas que meio que não faziam parte da minha issue, como a integração da tabela de alunos pra uma aula, a abertura e fechamento da presença e o tratamento da tabela pra refletir isso.

## Principais Arquivos

- src/data/mapper/lesson.mapper.ts
- src/data/models/lesson.model.ts
- src/data/requests/lesson.requests.ts
- src/pages/lessons-page/lessons-page.css
- src/pages/lessons-page/lessons-page.tsx
- src/pages/lesson-detail-page/lesson-detail-page.css
- src/pages/lesson-detail-page/lesson-detail-page.tsx

